### PR TITLE
Remove common leading whitespace?

### DIFF
--- a/plugin/copy-as-rtf.vim
+++ b/plugin/copy-as-rtf.vim
@@ -1,5 +1,5 @@
 " Vim plugin for copying syntax highlighted code as RTF on OS X systems
-" Last Change: 2011-07-24
+" Last Change: 2012-07-14
 " Maintainer:	Nathan Witmer <nwitmer@gmail.com>
 " License: WTFPL
 
@@ -21,10 +21,41 @@ function! s:CopyRTF(line1,line2)
     return
   endif
 
+  let lines = getline(a:line1, a:line2)
+  call s:RemoveCommonIndentation(a:line1, a:line2)
   call tohtml#Convert2HTML(a:line1, a:line2)
   silent exe "%!textutil -convert rtf -stdin -stdout | pbcopy"
   silent bd!
+  silent call setline(a:line1, lines)
   echomsg "RTF copied to clipboard"
+endfunction
+
+" outdent selection to the least indented level
+function! s:RemoveCommonIndentation(line1,line2)
+  let lines = getline(a:line1, a:line2)
+
+  for line in lines
+    let indent_level = match(line, '\S')
+
+    if indent_level < 0
+      " blank line or whitespace
+      continue
+    elseif indent_level == 0
+      return
+    else
+      if exists('minimum_indent')
+        if minimum_indent > indent_level
+          let minimum_indent = indent_level
+        endif
+      else
+        let minimum_indent = indent_level
+      end
+    endif
+  endfor
+
+  let pattern = '\s\{'.minimum_indent.'}'
+  call map(lines, 'substitute(v:val, pattern, "", "")')
+  call setline(a:line1, lines)
 endfunction
 
 command! -range=% CopyRTF :call s:CopyRTF(<line1>,<line2>)


### PR DESCRIPTION
Hi Nathan!

What do you think about removing common indentation up to the least-indented level? This prevents you from having to to manually remove the common leading whitespace when you copy a block of code that is all indented.

I would think that this is always desirable, but I could add this as a configurable option instead of having it be the default and only behavior if you would prefer. And if you don't want it at all that's fine too of course.

The downside to this implementation is that the text flashes at the outdented level before getting restored to its previous state. I didn't think of a way to avoid that but I don't see it as a big deal for the purposes of this plugin.

Thanks! Let me know what you think...
