### PR TITLE
Support Bash highlighting

### DIFF
--- a/plugin/copy-as-rtf.vim
+++ b/plugin/copy-as-rtf.vim
@@ -62,8 +62,14 @@ function! s:CopyRTF(bufnr, line1, line2)
     let l:orig_bg = &background
     let l:orig_nu = &number
     let l:orig_nuw = &numberwidth
+    if exists("b:is_bash")
+      let l:is_bash = b:is_bash
+    endif
     new __copy_as_rtf__
     " enable the same syntax highlighting
+    if exists("l:is_bash")
+      let b:is_bash=l:is_bash
+    endif
     let &ft=orig_ft
     let &background=l:orig_bg
     let &number=l:orig_nu


### PR DESCRIPTION
When copying a section of Bash script that doesn't include the
`#/bin/bash` shebang line, vim assumes that the copied text is ksh and
fails to properly highly bashism like `"${file/#*./.}"`. The vim
variable `b:is_bash` is used to set the type to bash.

This checks if `b:is_bash` is defined for the current buffer and if so,
sets it in the new buffer. It's important that this happen before
setting the filetype, although I didn't dig into why that is so.