### PR TITLE
Write HTML to a temporary file before converting

### DIFF
--- a/plugin/copy-as-rtf.vim
+++ b/plugin/copy-as-rtf.vim
@@ -86,9 +86,12 @@ function! s:CopyRTF(bufnr, line1, line2)
     endif
 
     call tohtml#Convert2HTML(1, line('$'))
-    silent exe "%!textutil -convert rtf -stdin -stdout | pbcopy"
+    let filename = tempname() ".html"
+    silent exe ":w!" filename
+    silent exe "%!textutil -convert rtf -stdout " filename " | pbcopy"
     silent bd!
     silent bd!
+    call delete(filename)
   endif
 
   let @# = l:alternate


### PR DESCRIPTION
This commit writes the HTML to a temporary file before sending it to
`textutil`.  This is a workaround for a bug in `textutil` in issue #10

This is just the workaround I'm using for issue #10